### PR TITLE
#160478374 Fix failing tests on article app when more tests are added to it.

### DIFF
--- a/authors/apps/articles/tests/test_update_delete.py
+++ b/authors/apps/articles/tests/test_update_delete.py
@@ -64,6 +64,3 @@ class ArticleDeleteUpdateTests(Base):
                                    **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['body'], self.article_data['body'])
-
-    def test(self):
-        pass

--- a/authors/apps/articles/tests/test_update_delete.py
+++ b/authors/apps/articles/tests/test_update_delete.py
@@ -7,10 +7,13 @@ from authors.apps.authentication.backends import generate_jwt_token
 class ArticleDeleteUpdateTests(Base):
     def setUp(self):
         super().setUp()
-        self.client.post(self.article_url, self.article_data,
-                         format="json", **self.headers)
+        response = self.client.post(self.article_url, self.article_data,
+                                    format="json", **self.headers)
+        self.article_id = response.data['id']
         self.retrieve_update_delete_url = reverse(
-            'articles:retrieveUpdateDelete', kwargs={'pk': 4})
+            'articles:retrieveUpdateDelete', kwargs={'pk': self.article_id})
+        self.non_existing_article_url = reverse(
+            'articles:retrieveUpdateDelete', kwargs={'pk': -1})
 
     def tearDown(self):
         super().tearDown()
@@ -20,8 +23,7 @@ class ArticleDeleteUpdateTests(Base):
         Tests that a client can delete a specific article
         """
         response = self.client.delete(
-            reverse(
-                'articles:retrieveUpdateDelete', kwargs={'pk': 5}),
+            self.retrieve_update_delete_url,
             format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -37,7 +39,7 @@ class ArticleDeleteUpdateTests(Base):
             "password": "kamila1990",
         }
         user_register = self.client.post(self.registration_url, user_data,
-                                    format='json')
+                                         format='json')
         token = generate_jwt_token(user_data['username'])
         activate = self.client.get(
             reverse("authentication:activate_user", args=[token]))
@@ -47,22 +49,21 @@ class ArticleDeleteUpdateTests(Base):
             response.data['token'])}
         self.client.post(self.article_url, self.article_data,
                          format="json", **headers)
-        response = self.client.delete(
-            reverse(
-                'articles:retrieveUpdateDelete', kwargs={'pk': 8}),
-            format="json",
-            **self.headers)
+        response = self.client.delete(self.retrieve_update_delete_url,
+                                      format="json",
+                                      **headers)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_can_edit_an_article(self):
         """
         Tests that a client can update details of an article
         """
-        response = self.client.put(
-            reverse(
-                'articles:retrieveUpdateDelete', kwargs={'pk': 6}),
-            data=self.article_data,
-            format="json",
-            **self.headers)
+        response = self.client.put(self.retrieve_update_delete_url,
+                                   data=self.article_data,
+                                   format="json",
+                                   **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['body'], self.article_data['body'])
+
+    def test(self):
+        pass


### PR DESCRIPTION
#### What does this PR do?
- fixes failing tests on article app when more tests are added
#### Description of Task to be completed?
- Refactor tests on `test_update_delete.py` and `test_retrieve_articles.py` files to grab the article ID on the base test and use it for subsequent requests.
#### How should this be manually tested?
- Clone [this](https://github.com/andela/ah-magnificent6.git) repository
- Copy everything on *.env-sample* to  *.env* [and set the environment variables]
- Create and activate a [virtual environment](https://docs.python.org/3/library/venv.html) inside the project base directory.
- Run the command `git checkout bg-fix-failing-tests-on-adding-more-tests-160478374`
- Install the project dependencies by running `pip install -r requirements.txt`
- Add a single test to `test_update_delete.py` or `test_retrieve_articles.py` files
- Run `python manage.py test` on your terminal
- Confirm that all existing tests before your new test are passing
#### Any background context you want to provide?
- Adding more tests to an app should not break the existing tests.
#### What are the relevant pivotal tracker stories?
[Fix failing tests when more tests are added to article app](https://www.pivotaltracker.com/story/show/160478374)
#### Screenshots 
Added a test to confirm whether the existing ones are passing and deleted it after confirmation.
![image](https://user-images.githubusercontent.com/9263906/45481946-7a7e4980-b755-11e8-9c50-550d412e4822.png)

Confirmation from the terminal
![image](https://user-images.githubusercontent.com/9263906/45481963-84a04800-b755-11e8-9afc-8a1de5b23901.png)
