### PR TITLE
[Feature #159965319] Add share urls to Article serializer

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.utils.text import slugify
 from django.core.validators import MinValueValidator, MaxValueValidator
+from rest_framework.reverse import reverse as api_reverse
+
 
 from authors.apps.authentication.models import User
 import uuid
@@ -46,6 +48,30 @@ class Article(models.Model):
             self.slug = slugify(self.title + '-' +
                                 uuid.uuid4().hex[:6])
         super().save(*args, **kwargs)
+
+    def get_share_uri(self, request=None):
+        """
+        Method to prepare and generate urls  for sharing the article to facebook,
+        twitter and email.
+        """
+        absolute_share_uri = api_reverse(
+            'articles:retrieveUpdateDelete',
+            kwargs={'slug': self.slug},
+            request=request)
+
+        uri_data = {
+            'twitter':
+            'https://twitter.com/intent/tweet?url={}'.format(
+                absolute_share_uri),
+            'facebook':
+            'https://www.facebook.com/sharer/sharer.php?u={}'.format(
+                absolute_share_uri),
+            'email':
+            'mailto:?subject=New Article Alert&body={}'.format(
+                absolute_share_uri)
+        }
+
+        return uri_data
 
 
 class ArticleRating(models.Model):

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -11,6 +11,7 @@ class ArticleSerializer(serializers.ModelSerializer):
     favourite = serializers.SerializerMethodField(method_name='get_favorite')
     favouritesCount = serializers.SerializerMethodField(
         method_name='get_favorites_count')
+    share_urls = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         """Declare all fields to be returned from the model of articles."""
@@ -32,7 +33,8 @@ class ArticleSerializer(serializers.ModelSerializer):
             "favouritesCount",
             "userLikes",
             "userDisLikes",
-            "rating_average"
+            "rating_average",
+            "share_urls"
         )
 
     def get_favorite(self, instance):
@@ -47,6 +49,14 @@ class ArticleSerializer(serializers.ModelSerializer):
     def get_favorites_count(self, instance):
         """Return the number of users who have favourited the atricle."""
         return instance.favourited.count()
+
+    def get_share_urls(self, instance):
+        """
+        Populates the share_urls field with the urls for facebook, twitter
+        and email.
+        """
+        request = self.context.get('request')
+        return instance.get_share_uri(request=request)
 
 
 class ArticleRatingSerializer(serializers.ModelSerializer):

--- a/authors/apps/articles/tests/test_retrieve_articles.py
+++ b/authors/apps/articles/tests/test_retrieve_articles.py
@@ -36,6 +36,7 @@ class ArticleTests(Base):
                                    format="json", **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data['slug'] == self.article_slug)
+        self.assertIsNotNone(response.data['share_urls'])
 
     def test_cannot_retrieve_a_non_existing_article(self):
         """

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -85,7 +85,8 @@ class ArticleDetailsView(generics.RetrieveUpdateDestroyAPIView):
         """
         article = self.get_object(slug)
         if article:
-            serializer = self.serializer_class(article)
+            serializer = self.serializer_class(
+                article, context={'request': request})
             return Response(serializer.data, status.HTTP_200_OK)
         else:
             # return error message indicating article requested is not found.

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -275,7 +275,7 @@ class SocialLoginView(generics.CreateAPIView):
     def create(self, request):
         """ Receives a provider and token and creates a new user,
             if the new user does not exist already.
-            The username is retreived and used to generate the JWT token 
+            The username is retreived and used to generate the JWT token
             used to access the apps endpoints.
         """
 
@@ -291,7 +291,8 @@ class SocialLoginView(generics.CreateAPIView):
         strategy = load_strategy(request)
         try:
             # Get backend corresponding to provider.
-            backend = load_backend(strategy=strategy, name=provider, redirect_uri=None)
+            backend = load_backend(
+                strategy=strategy, name=provider, redirect_uri=None)
 
             if isinstance(backend, BaseOAuth1):
                 # Get access_token and access token secret for Oauth1 used by Twitter


### PR DESCRIPTION
#### What does this PR do?
- Enable users to share articles

#### Description of task to be completed?
- Give authenticated users the ability to share articles via Facebook, Twitter and email

#### How should this be manually tested?
$ git clone https://github.com/andela/ah-magnificent6.git
$ git checkout ft-share-articles-159965319
$ cd ah-magnificent6
$ cp .env-sample .env [and set the environment variables]
$ python3 -m venv venv
$ source venv/bin/activate
(venv) $ pip install -r requirements.txt
(venv) $ python manage.py migrate
(venv) $ python manage.py runserver
Using [Postman](https://www.getpostman.com/) navigate to 
User registration: `POST {your-server-root}:8000/api/user/signup`
```
{
    "email": "author@user.user",
    "username": "author",
    "password": "good123456"
}
```

User Login: `POST {your-server-root}:8000/api/user/login`
```
{
    "email": "author@user.user",
    "password": "good123456"
}
```
Use the token from the response in the login as the authentication header while creating an article.

<img width="1388" alt="screen shot 2018-09-12 at 10 54 16" src="https://user-images.githubusercontent.com/39065274/45410426-500b8e00-b67a-11e8-91ed-49338b9f3ab3.png">

Create article : POST {your-server-root}:8000/api/articles/
```
{
"title": "My Journey to Andela",
 "description": "This article is about how I joined Andela",
"body": "This is my story to Andela"
}
```

> GET {your-server-root}:8000/api/articles/`<article-slug>`

```
{
    "Article": {
        "id": 3,
        "title": "Hello",
        "body": "Ehh",
        "description": "Test passed",
        "created_at": "2018-09-18T16:30:38.696266+03:00",
        "updated_at": "2018-09-18T16:30:38.696290+03:00",
        "published_at": "2018-09-18T16:30:38.696299+03:00",
        "slug": "hello-f4f52d",
        "image": "http://127.0.0.1:8000/media/static/images/no-img.jpg",
        "author": 1,
        "favourited": [],
        "favourite": false,
        "favouritesCount": 0,
        "userLikes": [],
        "userDisLikes": [],
        "rating_average": null,
        "share_urls": {
            "twitter": "https://twitter.com/intent/tweet?url=http://127.0.0.1:8000/api/articles/hello-f4f52d",
            "facebook": "https://www.facebook.com/sharer/sharer.php?u=http://127.0.0.1:8000/api/articles/hello-f4f52d",
            "email": "mailto:?subject=New Article Alert&body=http://127.0.0.1:8000/api/articles/hello-f4f52d"
        }
    }
}
```


#### What are the relevant pivotal tracker stories?
[#159965319](https://www.pivotaltracker.com/story/show/159965319)

#### Background Context
Since we are querying the API endpoint for data, we are not capable of performing redirects to the relevant channels for sharing purposes. 
That is why at the moment we are returning URLs that the user can then use to share the article.






