### PR TITLE
#160721036 show tags below the article opened by a user for reading

### DIFF
--- a/ui-mockups/src/article.html
+++ b/ui-mockups/src/article.html
@@ -14,8 +14,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Raleway" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Vidaloka" rel="stylesheet">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU"
-        crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
     <link rel="stylesheet" href="css/bootstrap.css">
     <link rel="stylesheet" href="css/style.css">
 
@@ -41,8 +40,7 @@
             <div class="navbar-text">
                 <ul class="navbar-nav mr-auto">
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown"
-                            aria-haspopup="true" aria-expanded="false">
+                        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             <i class="fas fa-user-circle"></i>
                         </a>
                         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
@@ -81,26 +79,16 @@
                         <div class="d-flex justify-content-between article">
                             <!-- Rating stars -->
                             <fieldset class="rating">
-                                <input type="radio" id="star5" name="rating" value="5" />
-                                <label class="full" for="star5" title="Awesome - 5 stars"></label>
-                                <input type="radio" id="star4half" name="rating" value="4 and a half" />
-                                <label class="half" for="star4half" title="Pretty good - 4.5 stars"></label>
-                                <input type="radio" id="star4" name="rating" value="4" />
-                                <label class="full" for="star4" title="Pretty good - 4 stars"></label>
-                                <input type="radio" id="star3half" name="rating" value="3 and a half" />
-                                <label class="half" for="star3half" title="Meh - 3.5 stars"></label>
-                                <input type="radio" id="star3" name="rating" value="3" />
-                                <label class="full" for="star3" title="Meh - 3 stars"></label>
-                                <input type="radio" id="star2half" name="rating" value="2 and a half" />
-                                <label class="half" for="star2half" title="Kinda bad - 2.5 stars"></label>
-                                <input type="radio" id="star2" name="rating" value="2" />
-                                <label class="full" for="star2" title="Kinda bad - 2 stars"></label>
-                                <input type="radio" id="star1half" name="rating" value="1 and a half" />
-                                <label class="half" for="star1half" title="Meh - 1.5 stars"></label>
-                                <input type="radio" id="star1" name="rating" value="1" />
-                                <label class="full" for="star1" title="Sucks big time - 1 star"></label>
-                                <input type="radio" id="starhalf" name="rating" value="half" />
-                                <label class="half" for="starhalf" title="Sucks big time - 0.5 stars"></label>
+                                <input type="radio" id="star5" name="rating" value="5" /><label class="full" for="star5" title="Awesome - 5 stars"></label>
+                                <input type="radio" id="star4half" name="rating" value="4 and a half" /><label class="half" for="star4half" title="Pretty good - 4.5 stars"></label>
+                                <input type="radio" id="star4" name="rating" value="4" /><label class="full" for="star4" title="Pretty good - 4 stars"></label>
+                                <input type="radio" id="star3half" name="rating" value="3 and a half" /><label class="half" for="star3half" title="Meh - 3.5 stars"></label>
+                                <input type="radio" id="star3" name="rating" value="3" /><label class="full" for="star3" title="Meh - 3 stars"></label>
+                                <input type="radio" id="star2half" name="rating" value="2 and a half" /><label class="half" for="star2half" title="Kinda bad - 2.5 stars"></label>
+                                <input type="radio" id="star2" name="rating" value="2" /><label class="full" for="star2" title="Kinda bad - 2 stars"></label>
+                                <input type="radio" id="star1half" name="rating" value="1 and a half" /><label class="half" for="star1half" title="Meh - 1.5 stars"></label>
+                                <input type="radio" id="star1" name="rating" value="1" /><label class="full" for="star1" title="Sucks big time - 1 star"></label>
+                                <input type="radio" id="starhalf" name="rating" value="half" /><label class="half" for="starhalf" title="Sucks big time - 0.5 stars"></label>
                             </fieldset>
                             <h5 class="p-1">
                                 <span class="badge badge-success">4.5</span>
@@ -143,47 +131,39 @@
                 <div class="list-group">
                     <div class=" d-flex justify-content-between ">
                         <div class="ml-2">
-                            "There is no one who loves pain itself, who seeks after it and wants to have it, simply
-                            because it is pain..." "There is no one who loves pain itself, who seeks after it and wants
-                            to have it, simply because it is pain..." "There is no one who loves pain
-                            itself, who seeks after it and wants to have it, simply because it is pain..." "There is no
-                            one who loves pain itself, who seeks after it and wants to have it, simply because it is
-                            pain..." "There is no one who loves pain itself,
-                            who seeks after it and wants to have it, simply because it is pain..." "There is no one who
-                            loves pain itself, who seeks after it and wants to have it, simply because it is pain..."
-                            "There is no one who loves pain itself, who
-                            seeks after it and wants to have it, simply because it is pain..." "There is no one who
-                            loves pain itself, who seeks after it and wants to have it, simply because it is pain..."
-                            "There is no one who loves pain itself, who seeks
-                            after it and wants to have it, simply because it is pain..." "There is no one who loves
-                            pain itself, who seeks after it and wants to have it, simply because it is pain..." "There
-                            is no one who loves pain itself, who seeks after
-                            it and wants to have it, simply because it is pain..." "There is no one who loves pain
-                            itself, who seeks after it and wants to have it, simply because it is pain..." "There is no
-                            one who loves pain itself, who seeks after it
-                            and wants to have it, simply because it is pain...There is no one who loves pain itself,
-                            who seeks after it and wants to have it, simply because it is pain..." "There is no one who
-                            loves pain itself, who seeks after it and
-                            wants to have it, simply because it is pain..." "There is no one who loves pain itself, who
-                            seeks after it and wants to have it, simply because it is pain..." "There is no one who
-                            loves pain itself, who seeks after it and wants
-                            to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks
-                            after it and wants to have it, simply because it is pain..." "There is no one who loves
-                            pain itself, who seeks after it and wants to
-                            have it, simply because it is pain..." "There is no one who loves pain itself, who seeks
-                            after it and wants to have it, simply because it is pain..." "There is no one who loves
-                            pain itself, who seeks after it and wants to have
-                            it, simply because it is pain..." "There is no one who loves pain itself, who seeks after
-                            it and wants to have it, simply because it is pain..." "There is no one who loves pain
-                            itself, who seeks after it and wants to have it,
-                            simply because it is pain..." "There is no one who loves pain itself, who seeks after it
-                            and wants to have it, simply because it is pain..." "There is no one who loves pain itself,
-                            who seeks after it and wants to have it, simply
-                            because it is pain..." "There is no one who loves pain itself, who seeks after it and wants
-                            to have it, simply because it is pain..." </div>
+                            "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain
+                            itself, who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself,
+                            who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who
+                            seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks
+                            after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after
+                            it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it
+                            and wants to have it, simply because it is pain...There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and
+                            wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants
+                            to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to
+                            have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have
+                            it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it,
+                            simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply
+                            because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." </div>
 
                     </div>
                     <div class="card-text d-flex justify-content-end p-2">
+                        <div class="d-flex justify-content-between">
+                            <ul class="tags">
+                                <li class="ml-1 mt-3 p-1">
+                                    <a href="">software</a>
+                                </li>
+                                <li class="ml-1 mt-3 p-1">
+                                    <a href="">python programming</a>
+                                </li>
+                                <li class="ml-1 mt-3 p-1">
+                                    <a href="">Learning by doing</a>
+                                </li>
+                                <li class="ml-1 mt-3 p-1">
+                                    <a href="">Programming</a>
+                                </li>
+                            </ul>
+
+                        </div>
                         <span class="likes">
                             <small><a href="" class="text-success"> <i class="fas fa-lg fa-thumbs-up"></i></a></small>
                             <small><a href="" class="text-warning"> <i class="fas fa-lg fa-thumbs-down"></i></a></small>
@@ -220,25 +200,24 @@
             </div>
         </div>
         <hr>
-        <div class="container">
-            <div class="row">
-                <div class="col-sm-4">
-                    <img src="assets/annie-spratt-558900-unsplash.jpg" class="rounded float-left mr-2" alt="post image"
-                        width="120" height="120">
-                    <div class="ml-2">
-                        <h6><a href="">Donec id elit non mi porta</a></h6>
+        <div class=" container ">
+            <div class=" row ">
+                <div class=" col-sm-4 ">
+                    <img src=" assets/annie-spratt-558900-unsplash.jpg " class=" rounded float-left mr-2 " alt=" post image " width=" 120 " height=" 120 ">
+                    <div class=" ml-2 ">
+                        <h6><a href=" ">Donec id elit non mi porta</a></h6>
                         <p>
-                            <small class="text-muted ah-list-content">
+                            <small class=" text-muted ah-list-content ">
                                 Donec id elit non mi porta gravida at eget metus. Maecenas sed diam eget risus
                                 varius blandit.
                             </small>
                         </p>
                         <small>
-                            <a class="ah-author-link" href="#">Meshack Mbuvi</a>
+                            <a class=" ah-author-link " href=" # ">Meshack Mbuvi</a>
                         </small>
-                        <p class="d-flex justify-content-between">
-                            <small class="text-muted">July 15.</small>
-                            <small class="text-muted">9 min read</small>
+                        <p class=" d-flex justify-content-between ">
+                            <small class=" text-muted ">July 15.</small>
+                            <small class=" text-muted ">9 min read</small>
                             <span class=" d-flex justify-content-end ">
                                 <small class="likes"><a href="" class="text-success"> <i class="fas fa-thumbs-up"></i></a></small>
                                 <small class="likes"><a href="" class="text-warning"> <i class="fas fa-thumbs-down"></i></a></small>
@@ -248,51 +227,49 @@
                         </p>
                     </div>
                 </div>
-                <div class="col-sm-4">
-                    <img src="assets/alisa-anton-632369-unsplash.jpg" class="rounded float-left mr-2" alt="post image"
-                        width="120" height="120">
-                    <div class="ml-2">
-                        <h6><a href="">Donec id elit non mi porta</a></h6>
+                <div class=" col-sm-4 ">
+                    <img src=" assets/alisa-anton-632369-unsplash.jpg " class=" rounded float-left mr-2 " alt=" post image " width=" 120 " height=" 120 ">
+                    <div class=" ml-2 ">
+                        <h6><a href=" ">Donec id elit non mi porta</a></h6>
                         <p>
-                            <small class="text-muted ah-list-content">
+                            <small class=" text-muted ah-list-content ">
                                 Donec id elit non mi porta gravida at eget metus. Maecenas sed diam eget risus
                                 varius blandit.
                             </small>
                         </p>
                         <small>
-                            <a class="ah-author-link" href="#">Meshack Mbuvi</a>
+                            <a class=" ah-author-link " href=" # ">Meshack Mbuvi</a>
                         </small>
-                        <p class="d-flex justify-content-between">
-                            <small class="text-muted">July 21.</small>
-                            <small class="text-muted">10 min read</small>
+                        <p class=" d-flex justify-content-between ">
+                            <small class=" text-muted ">July 21.</small>
+                            <small class=" text-muted ">10 min read</small>
                             <span class=" d-flex justify-content-end ">
-                                <small class="likes"><a href="" class="text-success"> <i class="fas fa-thumbs-up"></i></a></small>
-                                <small class="likes"><a href="" class="text-warning"> <i class="fas fa-thumbs-down"></i></a></small>
+                                <small class=" likes "><a href=" " class=" text-success "> <i class=" fas fa-thumbs-up "></i></a></small>
+                                <small class=" likes "><a href=" " class=" text-warning "> <i class=" fas fa-thumbs-down "></i></a></small>
                             </span>
                             <small><a href="" class="bookmark"> <i class="fas fa-bookmark"></i></i></a></small>
                         </p>
                     </div>
                 </div>
-                <div class="col-sm-4">
-                    <img src="assets/thought-catalog-575829-unsplash.jpg" class="rounded float-left mr-3" alt="post image"
-                        width="120" height="120">
-                    <div class="ml-2">
-                        <h6><a href="">Donec id elit non mi porta</a></h6>
+                <div class=" col-sm-4 ">
+                    <img src=" assets/thought-catalog-575829-unsplash.jpg " class=" rounded float-left mr-3 " alt=" post image " width=" 120 " height=" 120 ">
+                    <div class=" ml-2 ">
+                        <h6><a href=" ">Donec id elit non mi porta</a></h6>
                         <p>
-                            <small class="text-muted ah-list-content">
+                            <small class=" text-muted ah-list-content ">
                                 Donec id elit non mi porta gravida at eget metus. Maecenas sed diam eget risus
                                 varius blandit.
                             </small>
                         </p>
                         <small>
-                            <a class="ah-author-link" href="#">Meshack Mbuvi</a>
+                            <a class=" ah-author-link " href=" # ">Meshack Mbuvi</a>
                         </small>
-                        <p class="d-flex justify-content-between">
-                            <small class="text-muted">July 1.</small>
-                            <small class="text-muted">15 min read</small>
+                        <p class=" d-flex justify-content-between ">
+                            <small class=" text-muted ">July 1.</small>
+                            <small class=" text-muted ">15 min read</small>
                             <span class=" d-flex justify-content-end ">
-                                <small class="likes"><a href="" class="text-success"> <i class="fas fa-thumbs-up"></i></a></small>
-                                <small class="likes"><a href="" class="text-warning"> <i class="fas fa-thumbs-down"></i></a></small>
+                                <small class=" likes "><a href=" " class=" text-success "> <i class=" fas fa-thumbs-up "></i></a></small>
+                                <small class=" likes "><a href=" " class=" text-warning "> <i class=" fas fa-thumbs-down "></i></a></small>
                             </span>
                             <small><a href="" class="bookmark"> <i class="fas fa-bookmark"></i></i></a></small>
                         </p>
@@ -309,8 +286,7 @@
         </div>
     </div>
     <!--  Report Article Modal -->
-    <div class="modal fade" id="ahReportArticleModal" tabindex="-1" role="dialog" aria-labelledby="ahReportArticleModal"
-        aria-hidden="true">
+    <div class="modal fade" id="ahReportArticleModal" tabindex="-1" role="dialog" aria-labelledby="ahReportArticleModal" aria-hidden="true">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
@@ -340,7 +316,7 @@
     </div>
     <script>
         let followUnfollowBtn = document.getElementById('ah-follow-unfollow-btn')
-        followUnfollowBtn.addEventListener('click', function () {
+        followUnfollowBtn.addEventListener('click', function() {
             if (followUnfollowBtn.innerText === 'Follow') {
                 followUnfollowBtn.innerText = 'Unfollow'
             } else {
@@ -350,17 +326,22 @@
         })
         let fav = document.getElementById('fav')
         let button = document.getElementById('favourite')
-        button.addEventListener('click', function () {
-            if (fav.style.color === 'black') {
-                fav.style.color = 'green'
-            } else {
-                fav.style.color = 'black'
-            }
-        })
+        button.addEventListener('click', function() {
+                    if (fav.style.color === 'black') {
+                        fav.style.color = 'green'
+                    } else {
+                        fav.style.color = 'black'
+                        button.addEventListener('click', function() {
+                            if (fav.innerText === 'Favourite this article') {
+                                fav.innerText = 'Unfavourite this article'
+                            } else {
+                                fav.innerText = 'Favourite this article'
+                            }
+                        })
     </script>
-    <script src="https://use.fontawesome.com/11.4875c9fa.js"></script>
-    <script src="js/jquery.min.js" async defer></script>
-    <script src="js/bootstrap.min.js" async defer></script>
+    <script src=" https://use.fontawesome.com/11.4875c9fa.js "></script>
+    <script src=" js/jquery.min.js " async defer></script>
+    <script src=" js/bootstrap.min.js " async defer></script>
 </body>
 
 </html>

--- a/ui-mockups/src/article.html
+++ b/ui-mockups/src/article.html
@@ -145,30 +145,29 @@
                             simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply
                             because it is pain..." "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..." </div>
 
-                    </div>
-                    <div class="card-text d-flex justify-content-end p-2">
-                        <div class="d-flex justify-content-between">
-                            <ul class="tags">
-                                <li class="ml-1 mt-3 p-1">
-                                    <a href="">software</a>
-                                </li>
-                                <li class="ml-1 mt-3 p-1">
-                                    <a href="">python programming</a>
-                                </li>
-                                <li class="ml-1 mt-3 p-1">
-                                    <a href="">Learning by doing</a>
-                                </li>
-                                <li class="ml-1 mt-3 p-1">
-                                    <a href="">Programming</a>
-                                </li>
-                            </ul>
 
-                        </div>
+                    </div>
+                    <div class="d-flex justify-content-between">
+                        <ul class="tags">
+                            <li class="ml-1 mt-3 p-1">
+                                <a href="">software</a>
+                            </li>
+                            <li class="ml-1 mt-3 p-1">
+                                <a href="">python programming</a>
+                            </li>
+                            <li class="ml-1 mt-3 p-1">
+                                <a href="">Learning by doing</a>
+                            </li>
+                            <li class="ml-1 mt-3 p-1">
+                                <a href="">Programming</a>
+                            </li>
+                        </ul>
                         <span class="likes">
                             <small><a href="" class="text-success"> <i class="fas fa-lg fa-thumbs-up"></i></a></small>
                             <small><a href="" class="text-warning"> <i class="fas fa-lg fa-thumbs-down"></i></a></small>
                             <small><a href="" class="bookmark"> <i class="fas fa-bookmark"></i></i></a></small>
                         </span>
+
                     </div>
                     <!-- Comment section -->
                     <div class="comments row ml-2 border-top border-bottom Z no-gutters">

--- a/ui-mockups/src/css/style.css
+++ b/ui-mockups/src/css/style.css
@@ -294,10 +294,10 @@ h1 {
   background-color: #fff !important; }
 
 /** 
-    Search and filter CSS
+Search and filter CSS
 */
 /** 
-    Search and filter CSS
+Search and filter CSS
 */
 .search-container {
   margin-right: 1.5rem;
@@ -332,3 +332,22 @@ h1 {
     .filter-container .filter .reset-filters {
       display: block;
       margin-top: 1rem; }
+
+.tags {
+  font-size: 15px;
+  font-weight: 400; }
+
+ul {
+  list-style: none; }
+
+li {
+  float: left;
+  display: block;
+  border: #e0e0d4 1px solid;
+  border-radius: 2px; }
+
+li a:hover {
+  text-decoration: none; }
+
+li a {
+  color: #999999; }

--- a/ui-mockups/src/css/style.css
+++ b/ui-mockups/src/css/style.css
@@ -351,3 +351,22 @@ li a:hover {
 
 li a {
   color: #999999; }
+
+.tags {
+  font-size: 12px;
+  font-weight: 400; }
+
+.tags ul {
+  list-style: none; }
+
+.tags li {
+  float: left;
+  display: block;
+  border: #e0e0d4 1px solid;
+  border-radius: 2px; }
+
+.tags li a:hover {
+  text-decoration: none; }
+
+.tags li a {
+  color: #999999; }

--- a/ui-mockups/src/css/style.css
+++ b/ui-mockups/src/css/style.css
@@ -337,25 +337,6 @@ Search and filter CSS
   font-size: 15px;
   font-weight: 400; }
 
-ul {
-  list-style: none; }
-
-li {
-  float: left;
-  display: block;
-  border: #e0e0d4 1px solid;
-  border-radius: 2px; }
-
-li a:hover {
-  text-decoration: none; }
-
-li a {
-  color: #999999; }
-
-.tags {
-  font-size: 12px;
-  font-weight: 400; }
-
 .tags ul {
   list-style: none; }
 

--- a/ui-mockups/src/scss/style.scss
+++ b/ui-mockups/src/scss/style.scss
@@ -491,3 +491,30 @@ li a:hover {
 li a {
     color: $ah-secondary-text-color;
 }
+
+.tags {
+    font-size: 12px;
+    font-weight: 400;
+}
+
+.tags {
+    ul {
+        list-style: none;
+    }
+    ;
+    li {
+        float: left;
+        display: block;
+        border: $ah-secondary-color 1px solid;
+        border-radius: 2px;
+    }
+    ;
+    li a:hover {
+        text-decoration: none;
+    }
+    ;
+    li a {
+        color: $ah-secondary-text-color;
+    }
+    ;
+}

--- a/ui-mockups/src/scss/style.scss
+++ b/ui-mockups/src/scss/style.scss
@@ -321,8 +321,8 @@ h1 {
     margin-right: 10px;
 }
 
-.card-body{
-    .fa-user-circle{
+.card-body {
+    .fa-user-circle {
         font-size: 6.8rem;
         color: lightblue;
     }
@@ -357,7 +357,7 @@ h1 {
 }
 
 // notification dropdown style
-.notifications{
+.notifications {
     margin-right: 1rem;
     .dropdown-menu {
         min-width: 20rem;
@@ -412,23 +412,25 @@ h1 {
 .bookmark:hover {
     background-color: #fff !important;
 }
-        
+
 
 /** 
-    Search and filter CSS
+Search and filter CSS
 */
+
+
 /** 
-    Search and filter CSS
+Search and filter CSS
 */
-.search-container{
+
+.search-container {
     margin-right: 1.5rem;
     max-width: 300px;
     .fas {
         color: $ah-primary-color;
         font-size: 1.375rem;
     }
-
-    .search{
+    .search {
         -webkit-transition: width 0.3s ease;
         -moz-transition: width 0.3s ease;
         -o-transition: width 0.3s ease;
@@ -436,33 +438,56 @@ h1 {
     }
 }
 
-.filter-container{
+.filter-container {
     margin-top: 1rem;
-    .applied-filters{
+    .applied-filters {
         margin-left: 0.3125rem;
-        .alert{
+        .alert {
             padding: 2px 0.5rem;
             border-radius: 1rem;
         }
-        .filter-value:after{
+        .filter-value:after {
             content: '\2715';
             padding-left: 0.5rem;
             color: $ah-secondary-text-color;
             font-size: 0.75rem;
         }
     }
-    .filter{
+    .filter {
         margin-top: 1.5rem;
-        input{
+        input {
             margin-bottom: 1rem;
         }
-        .results{
+        .results {
             padding: 1rem;
         }
-
-        .reset-filters{
+        .reset-filters {
             display: block;
             margin-top: 1rem;
         }
     }
+}
+
+.tags {
+    font-size: 15px;
+    font-weight: 400;
+}
+
+ul {
+    list-style: none;
+}
+
+li {
+    float: left;
+    display: block;
+    border: $ah-secondary-color 1px solid;
+    border-radius: 2px;
+}
+
+li a:hover {
+    text-decoration: none;
+}
+
+li a {
+    color: $ah-secondary-text-color;
 }

--- a/ui-mockups/src/scss/style.scss
+++ b/ui-mockups/src/scss/style.scss
@@ -473,30 +473,6 @@ Search and filter CSS
     font-weight: 400;
 }
 
-ul {
-    list-style: none;
-}
-
-li {
-    float: left;
-    display: block;
-    border: $ah-secondary-color 1px solid;
-    border-radius: 2px;
-}
-
-li a:hover {
-    text-decoration: none;
-}
-
-li a {
-    color: $ah-secondary-text-color;
-}
-
-.tags {
-    font-size: 12px;
-    font-weight: 400;
-}
-
 .tags {
     ul {
         list-style: none;


### PR DESCRIPTION
#### What does this pull request do
- Adds article tags below a single article which is being read by a user.

#### Description of tasks to be completed
- Add list items showing tags below an opened article

#### How should this be manually tested
- Clone this repository
- Run the command `git checkout ft-show-tags-below-article-160721036`
- change directory to `ui-mockups` by executing `cd ui-mockups` in your terminal
- Do the following commands to set your environment for testing using your terminal
    - Install [node](https://treehouse.github.io/installation-guides/mac/node-mac.html)
    - Run `npm install` to install all packages defined in `package.json` file
    - npm install gulp-cli -g
    - npm install gulp -D
- After executing above commands,type `gulp` and hit `[Enter]` button
- On your browser, visit the follwing pages
    - http://localhost:3000/article.html
#### Any background context you want to provide?
Having mockups is important in every API development because it helps to visualize how the user interface will look like in the finished product.
#### What are the relevant pivotal tracker stories?
[#160721036 display article tags for an opened article](https://www.pivotaltracker.com/story/show/160721036)
#### Screenshots
![image](https://user-images.githubusercontent.com/9263906/45953072-a4672400-c011-11e8-8aa7-661f21eee702.png)
