### PR TITLE
[Bug]: fix status code for a non-existing email address

### DIFF
--- a/authors/apps/authentication/tests/test_reset_password.py
+++ b/authors/apps/authentication/tests/test_reset_password.py
@@ -15,7 +15,7 @@ class ResetPassword(APITestCase):
             "username": "michael",
             "email": "michael.nthiwa@andela.com",
             "password": "Bit22150"}
-        self.client.defaults['HTTP_ORIGIN'] = '127.0.0.1'
+        self.client.defaults['HTTP_REFERER'] = '127.0.0.1'
 
         self.client.post(reverse('authentication:register'),
                          self.valid_user, format='json')

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -201,11 +201,12 @@ class ForgotPasswordAPIView(APIView):
             return Response({"message": "The email you entered does not exist"}, status=status.HTTP_404_NOT_FOUND)
 
         # Get URL for client and include in the email for resetting password
-        current_site_domain = request.META['HTTP_ORIGIN']
+        client_url = request.META['HTTP_REFERER'].replace(
+            "login", "reset-password/")
         # generate token
         token = default_token_generator.make_token(user)
-        reset_link_url = furl.furl(
-            '{}/reset-password/'.format(current_site_domain))
+        # format url and send it in the reset email link
+        reset_link_url = furl.furl(client_url)
         reset_link_url.args = (('token', token), ('email', user.email))
 
         # Sends mail with url, path of reset password and token


### PR DESCRIPTION
#### What does this PR do?
- changes status code for a non-existing email address from 200 to 404

#### Description of tasks to be completed
- read HTTP_REFERER of the request object to include it in the link send to a user to reset password
- set HTTP_REFERER in client defaults for forgot password tests

#### How should this be manually tested?
- Clone [this](https://github.com/andela/ah-magnificent6.git) repository
- Copy everything on *.env-sample* to  *.env* [and set the environment variables]
- Create and activate a [virtual environment](https://docs.python.org/3/library/venv.html) inside the project base directory.
- Run the command `git checkout bg-forgot-password-status-code-161199151`
- Install the project dependencies by running `pip install -r requirements.txt`
- Run the server by issuing the command `python manage.py runserver`
- Using ([Postman](https://www.getpostman.com/) or your favorite REST API client, 
- Access  `/api/accounts/forgot_password/` using a `notexisting@notthere.com` email address
- Examine the response you get; it should have a status code of 404 and a message

#### Any background context you want to provide?
Using correct status code for various server response is vital in any application because it helps one know the context behind a given response.

#### What are the relevant pivotal tracker stories?
[Fix status code error](https://www.pivotaltracker.com/story/show/161199151)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/9263906/46906503-31b0e080-cf0d-11e8-9645-9bbc6cfd106e.png)
