### PR TITLE
#161343997 Fix redirect upon email activation

### DIFF
--- a/authors/apps/authentication/tests/test_validation.py
+++ b/authors/apps/authentication/tests/test_validation.py
@@ -37,7 +37,7 @@ class VerifyTestCase(TestCase):
             reverse("authentication:activate_user", args=[token]))
         user = User.objects.get(username=self.user['username'])
         self.assertTrue(user.is_active)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
 
     def test_non_existing_user_token(self):
         """Test unsuccessful token verification."""

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -12,6 +12,7 @@ from django.contrib.auth.tokens import default_token_generator
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import send_mail
+from django.shortcuts import redirect
 
 from .renderers import UserJSONRenderer
 from .serializers import (
@@ -266,9 +267,7 @@ class UserActivationAPIView(APIView):
                 status=status.HTTP_400_BAD_REQUEST)
         user.is_active = True
         user.save()
-        return Response(
-            data={"message": "Account was verified successfully"},
-            status=status.HTTP_200_OK)
+        return redirect("https://magnificent6-frontend.herokuapp.com/login")
 
 
 class SocialLoginView(generics.CreateAPIView):


### PR DESCRIPTION
#### What does this PR do?
- Allows users to be redirected to log in after registration.

#### Description of task to be completed?
- A user is redirected to login in order to login after clicking email activation link.

#### How should this be manually tested?
$ git clone https://github.com/andela/ah-magnificent6.git
$ git checkout ft-comment-article-159965308
$ cd ah-magnificent6
$ cp .env-sample .env [and set the environment variables]
$ python3 -m venv venv
$ source venv/bin/activate
(venv) $ pip install -r requirements.txt
(venv) $ python manage.py migrate
(venv) $ python manage.py runserver

Using [Postman](https://www.getpostman.com/) navigate to 
User registration: `POST {your-server-root}:8000/api/user/signup`

```
{
    "email": "user1@user.user",
    "username": "user1",
    "password": "User$#@!"
}
```

Click the link sent to your email and it will redirect you to the frontend login page.